### PR TITLE
Add biocviews: to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     rmarkdown,
     grid,
     gridBase
+biocViews:
 LazyData: true
 VignetteBuilder: knitr
 License: Apache License 2.0


### PR DESCRIPTION
Installing `speaq` can be a bit tricky due to it having Bioconductor dependencies.

The `remotes` package looks for the `biocviews:` field in the DESCRIPTION in order to enable bioconductor repositories and install dependencies automatically. This is a formally undocumented trick.

This approach is already being used in the [`enviGCMS`](https://cran.r-project.org/web/packages/enviGCMS/index.html) CRAN package.

It is also commented [here](https://github.com/r-lib/devtools/issues/700#issuecomment-235127291) and [here](https://bioinformatics.stackexchange.com/a/3367), as well as used in the [PhenotypeSimulator (github)](https://github.com/HannahVMeyer/PhenotypeSimulator) package.

Even though it is an undocumented solution, having `biocviews` in the `DESCRIPTION` would make it easier to install `speaq` for some users.

Thanks